### PR TITLE
Fix typo in README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
-  - pip install "pytest>=3.6" pytest-cov coveralls
+  - pip install -r requirements.test.txt
 script:
   - python -m pytest test --cov=ridi
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
-  - pip install pytest>=3.6 pytest-cov coveralls
+  - pip install "pytest>=3.6" pytest-cov coveralls
 script:
   - python -m pytest test --cov=ridi
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
-  - pip install pytest pytest-cov coveralls
+  - pip install pytest>=3.6 pytest-cov coveralls
 script:
   - python -m pytest test --cov=ridi
 after_success:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Without secret-keeper, you would have:
 - hard-coded your secrets in your version-controlled source code (Worst!), or
 - created a not-version-controlled config file and manually provide it when you deploy your code, or
-- let your deployment system - Jenkins CI, etc - mananage your not-version-controlled config file, but you have as many of them as your projects.
+- let your deployment system - Jenkins CI, etc - manage your not-version-controlled config file, but you have as many of them as your projects.
 
 With secret-keeper, you can:
 - store your secrets in AWS and let your applications use it safely and conveniently.

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,4 @@
+pytest>=3.6
+pytest-cov
+coveralls
+


### PR DESCRIPTION
Includes the smallest fix that change `mananage` to `manage`